### PR TITLE
Fixes #30. Fix test for data-saving, add data-saving='false' on init

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -213,6 +213,7 @@ function showFileEditor(dir, filename) {
 					if (result.status === 'success') {
 						// Save mtime
 						$('#editor').attr('data-mtime', result.data.mtime);
+						$('#editor').attr('data-saving', 'false');
 						// Initialise the editor
 						if (window.FileList){
 							FileList.setViewerMode(true);
@@ -260,7 +261,7 @@ function showFileEditor(dir, filename) {
 								sender: "editor"
 							},
 							exec: function () {
-								if(!$('#editor').attr('data-saving')){
+								if($('#editor').attr('data-saving') == 'false'){
 									doFileSave();
 								}
 							}


### PR DESCRIPTION
Fixes https://github.com/owncloud/files_texteditor/issues/30

@jancborchardt @labkode

To test: make some changes, press Ctrl+s (or equiv on mac), make more changes, use Ctrl+s again.

Previous: Would not save the second time.
Now: Saving should work more than once with the shortcut.
