### PR TITLE
improved error handling if something goes wrong

### DIFF
--- a/ajax/loadfile.php
+++ b/ajax/loadfile.php
@@ -30,25 +30,33 @@ OCP\JSON::checkLoggedIn();
 // Set the session key for the file we are about to edit.
 $dir = isset($_GET['dir']) ? $_GET['dir'] : '';
 $filename = isset($_GET['file']) ? $_GET['file'] : '';
-if(!empty($filename))
-{
-	$path = $dir.'/'.$filename;
-	$writeable = \OC\Files\Filesystem::isUpdatable($path);
-	$mime = \OC\Files\Filesystem::getMimeType($path);
-	$mtime = \OC\Files\Filesystem::filemtime($path);
-	$filecontents = \OC\Files\Filesystem::file_get_contents($path);
-	$encoding = mb_detect_encoding($filecontents."a", "UTF-8, WINDOWS-1252, ISO-8859-15, ISO-8859-1, ASCII", true);
-	if ($encoding == "") {
-		// set default encoding if it couldn't be detected
-		$encoding = 'ISO-8859-15';
+$l = \OC::$server->getL10N('files_texteditor');
+
+try {
+
+	if (!empty($filename)) {
+		$path = $dir . '/' . $filename;
+		$writeable = \OC\Files\Filesystem::isUpdatable($path);
+		$mime = \OC\Files\Filesystem::getMimeType($path);
+		$mtime = \OC\Files\Filesystem::filemtime($path);
+		$filecontents = \OC\Files\Filesystem::file_get_contents($path);
+		$encoding = mb_detect_encoding($filecontents . "a", "UTF-8, WINDOWS-1252, ISO-8859-15, ISO-8859-1, ASCII", true);
+		if ($encoding == "") {
+			// set default encoding if it couldn't be detected
+			$encoding = 'ISO-8859-15';
+		}
+		$filecontents = iconv($encoding, "UTF-8", $filecontents);
+		OCP\JSON::success(array('data' => array(
+				'filecontents' => $filecontents,
+				'writeable' => $writeable,
+				'mime' => $mime,
+				'mtime' => $mtime))
+		);
+	} else {
+		OCP\JSON::error(array('data' => array('message' => $l->t('Invalid file path supplied.'))));
 	}
-	$filecontents = iconv($encoding, "UTF-8", $filecontents);
-	OCP\JSON::success(array('data' => array(
-		'filecontents' => $filecontents,
-		'writeable' => $writeable,
-		'mime' => $mime,
-		'mtime' => $mtime))
-	);
-} else {
-	OCP\JSON::error(array('data' => array( 'message' => 'Invalid file path supplied.')));
+
+} catch (\Exception $e) {
+	$hint = method_exists($e, 'getHint') ? $e->getHint() : $e->getMessage();
+	OCP\JSON::error(array('data' => array('message' => $hint)));
 }


### PR DESCRIPTION
Return error message in case something goes wrong while reading a file (e.g. because it is encrypted and the user doesn't has the correct key)

cc @PVince81 @nickvergessen  @th3fallen 