### PR TITLE
Txt file that contains Chinese garbage problem

### DIFF
--- a/ajax/loadfile.php
+++ b/ajax/loadfile.php
@@ -37,7 +37,7 @@ if(!empty($filename))
 	$mime = \OC\Files\Filesystem::getMimeType($path);
 	$mtime = \OC\Files\Filesystem::filemtime($path);
 	$filecontents = \OC\Files\Filesystem::file_get_contents($path);
-	$encoding = mb_detect_encoding($filecontents."a", "UTF-8, WINDOWS-1252, ISO-8859-15, ISO-8859-1, ASCII", true);
+	$encoding = mb_detect_encoding($filecontents."a", "UTF-8, GBK, WINDOWS-1252, ISO-8859-15, ISO-8859-1, ASCII", true);
 	if ($encoding == "") {
 		// set default encoding if it couldn't be detected
 		$encoding = 'ISO-8859-15';


### PR DESCRIPTION
I was in China, made a temporary correction.
I do not know there is no effect on other countries.
According mb_detect_encoding function, change the order of the parameters can be adjusted later encoding truncated.
