### PR TITLE
Do not show actual error message

### DIFF
--- a/controller/filehandlingcontroller.php
+++ b/controller/filehandlingcontroller.php
@@ -103,8 +103,7 @@ class FileHandlingController extends Controller{
 			}
 
 		} catch (\Exception $e) {
-			$hint = method_exists($e, 'getHint') ? $e->getHint() : $e->getMessage();
-			return new DataResponse(['message' => (string)$hint], Http::STATUS_BAD_REQUEST);
+			return new DataResponse(['message' => 'An internal server error occurred.'], Http::STATUS_BAD_REQUEST);
 		}
 	}
 

--- a/tests/controller/filehandlingcontrollertest.php
+++ b/tests/controller/filehandlingcontrollertest.php
@@ -131,7 +131,7 @@ class FileHandlingControllerTest extends TestCase {
 
 		$this->assertSame(400, $result->getStatus());
 		$this->assertArrayHasKey('message', $data);
-		$this->assertSame($exceptionHint, $data['message']);
+		$this->assertSame('An internal server error occurred.', $data['message']);
 	}
 
 	/**


### PR DESCRIPTION
In case of not existant files this could leak informations such as the full path.

Fixes https://github.com/owncloud/security-tracker/issues/180