### PR TITLE
Add api that allows other app to register "previews" by mimetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,39 @@ files_texteditor
 A text editor app for ownCloud
 
 To see which files are editable, see [here](https://github.com/owncloud/files_texteditor/blob/master/js/editor.js)
+
+
+Preview apps
+----
+
+Apps can add side-by-side previews to the app for certain file types by using the preview api
+
+```js
+
+OCA.MYApp.Preview = function(){
+    ...
+}
+
+OCA.MYApp.Preview.Prototype = {
+    /**
+     * Give the app the opportunity to load any resources it needs and prepare for rendering a preview
+     */
+    init: function() {
+        ...
+    },
+    /**
+     * @param {string} the text to create the preview for
+     * @param {jQuery} the jQuery element to render the preview in
+     */
+    preview: function(text, previewElement) {
+        ...
+    }
+}
+
+OCA.Files_Texteditor.registerPreviewPlugin('text/markdown', new OCA.MYApp.Preview());
+
+```
+
+For styling of the preview, the preview element will have the id `preview` and the className will be set to the mimetype of the file being eddited with any slash replaced by dashes.
+
+e.g. when editing a markdown file the preview element can be styled using the `#preview.text-markdown` css query.

--- a/css/style.css
+++ b/css/style.css
@@ -41,7 +41,7 @@
 	left: 15%;
 	width: 70%;
     height: 88%;
-    z-index:1002;
+    z-index: 9999;
     overflow: hidden;
     background-color: #fff;
 	border-radius: 3px;
@@ -49,6 +49,7 @@
 }
 
 #editor_container.hasPreview {
+	z-index: 1002;
 	width: 100%;
 	height: 100%;
 	top: 0;

--- a/css/style.css
+++ b/css/style.css
@@ -47,6 +47,34 @@
 	border-radius: 3px;
 }
 
+#editor_container.hasPreview {
+	width: 100%;
+	height: 100%;
+	top: 0;
+	left: 0;
+	border: none;
+	margin-top: 45px;
+	border-radius: 0px;
+}
+
+#editor_container.hasPreview #preview {
+	display:block;
+}
+
+#editor_container.hasPreview #editor {
+	width: 50%;
+}
+
+#preview {
+	right: 0;
+	position: absolute;
+	top: 0;
+	display: none;
+	height: 100%;
+	width:50%;
+	padding-top: 46px;
+}
+
 @media(max-width: 768px) {
 	#editor_container {
 		width: 100%;
@@ -56,6 +84,14 @@
 		border: none;
 		margin-top: 45px;
 		border-radius: 0px;
+	}
+
+	#editor_container.hasPreview #preview {
+		display: none;
+	}
+
+	#editor_container.hasPreview #editor {
+		width: 100%;
 	}
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -58,7 +58,7 @@
 	border-radius: 0;
 }
 
-#editor_container.hasPreview #preview {
+#editor_container.hasPreview #preview, #editor_container.hasPreview #preview_wrap {
 	display:block;
 }
 
@@ -81,6 +81,7 @@
 	right: 0;
 	position: absolute;
 	top: 0;
+	display: none;
 	padding-top: 91px; /** main navigation + controls */
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -41,10 +41,11 @@
 	left: 15%;
 	width: 70%;
     height: 88%;
-    z-index:9999;
+    z-index:1002;
     overflow: hidden;
     background-color: #fff;
 	border-radius: 3px;
+	box-sizing: border-box;
 }
 
 #editor_container.hasPreview {
@@ -53,8 +54,7 @@
 	top: 0;
 	left: 0;
 	border: none;
-	margin-top: 45px;
-	border-radius: 0px;
+	border-radius: 0;
 }
 
 #editor_container.hasPreview #preview {
@@ -65,14 +65,33 @@
 	width: 50%;
 }
 
-#preview {
+#editor_container.hasPreview #editor_controls {
+	top: 45px;
+}
+
+#editor_container.hasPreview #editor_wrap {
+	padding-top: 91px; /** main navigation + controls */
+}
+
+#preview_wrap {
+	box-sizing: border-box;
+	height: 100%;
+	width: 50%;
 	right: 0;
 	position: absolute;
 	top: 0;
+	padding-top: 91px; /** main navigation + controls */
+}
+
+#preview {
+	overflow: auto;
+	box-sizing: border-box;
+	padding: 15px;
 	display: none;
 	height: 100%;
-	width:50%;
-	padding-top: 46px;
+	width:100%;
+	color: #252525;
+	background-color: #f9f9f9;
 }
 
 @media(max-width: 768px) {
@@ -82,8 +101,15 @@
 		top: 0;
 		left: 0;
 		border: none;
-		margin-top: 45px;
-		border-radius: 0px;
+		border-radius: 0;
+	}
+
+	#editor_controls {
+		top: 45px;
+	}
+
+	#editor_wrap {
+		padding-top: 91px; /** main navigation + controls */
 	}
 
 	#editor_container.hasPreview #preview {

--- a/js/editor.js
+++ b/js/editor.js
@@ -278,6 +278,7 @@ var Files_Texteditor = {
 					_self.previewPluginOnChange = _.debounce(_self.previewPlugins[file.mime].preview, 200);
 					var text = window.aceEditor.getSession().getValue();
 					_self.previewPluginOnChange(text, _self.preview);
+					window.aceEditor.resize();
 				} else {
 					_self.previewPluginOnChange = null;
 				}

--- a/js/editor.js
+++ b/js/editor.js
@@ -250,7 +250,8 @@ var Files_Texteditor = {
 		container.html(
 			'<div id="editor_overlay"></div>'
 			+'<div id="editor_container" class="icon-loading">'
-			+'<div id="editor_wrap"><div id="editor"></div><div id="preview"></div></div></div>');
+			+'<div id="editor_wrap"><div id="editor"></div>'
+			+'<div id="preview_wrap"><div id="preview"></div></div></div></div>');
 		$('#app-content').append(container);
 
 		// Get the file data

--- a/js/editor.js
+++ b/js/editor.js
@@ -43,6 +43,22 @@ var Files_Texteditor = {
 	saveTimer: null,
 
 	/**
+	 * preview plugins by mimetype
+	 */
+	previewPlugins: {},
+
+	registerPreviewPlugin: function(mimeType, plugin) {
+		this.previewPlugins[mimeType] = plugin;
+	},
+
+	/**
+	 * preview element
+	 */
+	preview: null,
+
+	previewPluginOnChange: null,
+
+	/**
 	 * Save handler, triggered by the button, or keyboard
 	 */
 	_onSaveTrigger: function() {
@@ -168,6 +184,10 @@ var Files_Texteditor = {
 				OCA.Files_Texteditor._onUnsaved();
 			}
 		}
+		if (this.previewPluginOnChange) {
+			var text = window.aceEditor.getSession().getValue();
+			this.previewPluginOnChange(text, this.preview);
+		}
 	},
 
 	/**
@@ -187,6 +207,9 @@ var Files_Texteditor = {
 		this.$container = container;
 		this.registerFileActions();
 		this.oldTitle = document.title;
+		$.each(this.previewPlugins, function(mime, plugin) {
+			plugin.init();
+		});
 	},
 
 	/**
@@ -227,7 +250,7 @@ var Files_Texteditor = {
 		container.html(
 			'<div id="editor_overlay"></div>'
 			+'<div id="editor_container" class="icon-loading">'
-			+'<div id="editor_wrap"><div id="editor"></div></div></div>');
+			+'<div id="editor_wrap"><div id="editor"></div><div id="preview"></div></div></div>');
 		$('#app-content').append(container);
 
 		// Get the file data
@@ -246,6 +269,17 @@ var Files_Texteditor = {
 				_self.loadControlBar(file, _self.currentContext);
 				window.aceEditor.getSession().on('change', _self.setupAutosave);
 				window.aceEditor.focus();
+
+				if (_self.previewPlugins[file.mime]){
+					_self.preview = container.find('#preview');
+					_self.preview.addClass(file.mime.replace('/','-'));
+					container.find('#editor_container').addClass('hasPreview');
+					_self.previewPluginOnChange = _.debounce(_self.previewPlugins[file.mime].preview, 200);
+					var text = window.aceEditor.getSession().getValue();
+					_self.previewPluginOnChange(text, _self.preview);
+				} else {
+					_self.previewPluginOnChange = null;
+				}
 			},
 			function(message){
 				// Oh dear
@@ -327,7 +361,7 @@ var Files_Texteditor = {
 			}
 		);
 		// Bind the edit event
-		window.aceEditor.getSession().on('change', this._onEdit);
+		window.aceEditor.getSession().on('change', this._onEdit.bind(this));
 		// Bind save trigger
 		window.aceEditor.commands.addCommand({
 			name: "save",


### PR DESCRIPTION
Allows 3rdparty apps to register previews for certain mimetypes.

Example usage: https://github.com/icewind1991/owncloud-markdown/tree/texteditor-2.0

cc @jancborchardt @tomneedham 

![markdown](https://cloud.githubusercontent.com/assets/1283854/9578279/b6471802-4fe8-11e5-8482-817cfa25211d.png)
