### PR TITLE
Only load scripts when needed

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -2,16 +2,13 @@
 
 // only load text editor if the user is logged in
 if (\OCP\User::isLoggedIn()) {
-	$request = \OC::$server->getRequest();
-
-	if (isset($request->server['REQUEST_URI'])) {
-		$url = $request->server['REQUEST_URI'];
-		if (preg_match('%index.php/apps/files(/.*)?%', $url)	|| preg_match('%index.php/s/(/.*)?%', $url)) {	
-			OCP\Util::addStyle('files_texteditor', 'DroidSansMono/stylesheet');
-			OCP\Util::addStyle('files_texteditor', 'style');
-			OCP\Util::addStyle('files_texteditor', 'mobile');
-			OCP\Util::addscript('files_texteditor', 'editor');
-			OCP\Util::addscript('files_texteditor', 'vendor/ace/src-noconflict/ace');
-		}
-	}
+	$eventDispatcher = \OC::$server->getEventDispatcher();
+	$eventDispatcher->addListener('OCA\Files::loadAdditionalScripts', function() {
+		OCP\Util::addStyle('files_texteditor', 'DroidSansMono/stylesheet');
+		OCP\Util::addStyle('files_texteditor', 'style');
+		OCP\Util::addStyle('files_texteditor', 'mobile');
+		OCP\Util::addscript('files_texteditor', 'editor');
+		OCP\Util::addscript('files_texteditor', 'vendor/ace/src-noconflict/ace');
+	});
 }
+


### PR DESCRIPTION
This will only load the scripts and CSS whenever the files app is displayed (and reduce the risk of side-effects on pages where the text editor is not intended to be used, like public links)

@tomneedham @LukasReschke