### PR TITLE
fix error messages in case a file couldn't be read

### DIFF
--- a/controller/filehandlingcontroller.php
+++ b/controller/filehandlingcontroller.php
@@ -24,10 +24,10 @@ namespace OCA\Files_Texteditor\Controller;
 
 
 use OC\Files\View;
+use OC\HintException;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
-use OCP\IConfig;
 use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IRequest;
@@ -108,12 +108,11 @@ class FileHandlingController extends Controller{
 				return new DataResponse(['message' => (string)$this->l->t('Invalid file path supplied.')], Http::STATUS_BAD_REQUEST);
 			}
 
+		} catch (HintException $e) {
+			$message = (string)$e->getHint();
+			return new DataResponse(['message' => $message], Http::STATUS_BAD_REQUEST);
 		} catch (\Exception $e) {
-			if(method_exists($e, 'getHint')) {
-				$message = (string)$e->getHint();
-			} else {
-				$message = (string)$this->l->t('An internal server error occurred.');
-			}
+			$message = (string)$this->l->t('An internal server error occurred.');
 			return new DataResponse(['message' => $message], Http::STATUS_BAD_REQUEST);
 		}
 	}

--- a/controller/filehandlingcontroller.php
+++ b/controller/filehandlingcontroller.php
@@ -109,7 +109,12 @@ class FileHandlingController extends Controller{
 			}
 
 		} catch (\Exception $e) {
-			return new DataResponse(['message' => 'An internal server error occurred.'], Http::STATUS_BAD_REQUEST);
+			if(method_exists($e, 'getHint')) {
+				$message = (string)$e->getHint();
+			} else {
+				$message = (string)$this->l->t('An internal server error occurred.');
+			}
+			return new DataResponse(['message' => $message], Http::STATUS_BAD_REQUEST);
 		}
 	}
 

--- a/tests/controller/filehandlingcontrollertest.php
+++ b/tests/controller/filehandlingcontrollertest.php
@@ -116,7 +116,25 @@ class FileHandlingControllerTest extends TestCase {
 		);
 	}
 
-	public function testLoadException() {
+	public function testLoadExceptionWithNoHint() {
+
+		$exceptionHint = 'test exception';
+
+		$this->viewMock->expects($this->any())
+			->method('file_get_contents')
+			->willReturnCallback(function() use ($exceptionHint) {
+				throw new \Exception();
+			});
+
+		$result = $this->controller->load('/', 'test.txt');
+		$data = $result->getData();
+
+		$this->assertSame(400, $result->getStatus());
+		$this->assertArrayHasKey('message', $data);
+		$this->assertSame('An internal server error occurred.', $data['message']);
+	}
+
+	public function testLoadExceptionWithHint() {
 
 		$exceptionHint = 'test exception';
 
@@ -131,7 +149,7 @@ class FileHandlingControllerTest extends TestCase {
 
 		$this->assertSame(400, $result->getStatus());
 		$this->assertArrayHasKey('message', $data);
-		$this->assertSame('An internal server error occurred.', $data['message']);
+		$this->assertSame($exceptionHint, $data['message']);
 	}
 
 	/**


### PR DESCRIPTION
if the exception contain a hint what went wrong we display it to the user if not we display a generic error message

fix bug introduced here: https://github.com/owncloud/files_texteditor/pull/96

cc @DeepDiver1975 @LukasReschke @tomneedham 