### PR TITLE
[Plugin] do not convert mtime to int 

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -34,6 +34,6 @@ $app->registerRoutes($this, array('routes' => array(
 	[
 		'name' => 'FileHandling#save',
 		'url' => '/ajax/savefile',
-		'verb' => 'PUT'
+		'verb' => 'POST'
 	]
 )));

--- a/controller/filehandlingcontroller.php
+++ b/controller/filehandlingcontroller.php
@@ -131,7 +131,7 @@ class FileHandlingController extends Controller{
 
 		if($path !== '' && (is_integer($mtime) && $mtime > 0)) {
 			// Get file mtime
-			$filemtime = $this->view->filemtime($path);
+			$filemtime = intval($this->view->filemtime($path));
 			if($mtime !== $filemtime) {
 				// Then the file has changed since opening
 				$this->logger->error('File: ' . $path . ' modified since opening.',

--- a/js/editor.js
+++ b/js/editor.js
@@ -512,7 +512,7 @@ var Files_Texteditor = {
 			var path = file.dir + '/' + file.name;
 		}
 		$.ajax({
-			type: 'PUT',
+			type: 'POST',
 			url: OC.generateUrl('/apps/files_texteditor/ajax/savefile'),
 			data: {
 				filecontents: data,


### PR DESCRIPTION
Our storage reports mtime with mililseconds (float). Comnverting to int means that the mtimes always mismatch and file cannot be saved.
