### PR TITLE
Fix Shift-JIS code misdetection

### DIFF
--- a/controller/filehandlingcontroller.php
+++ b/controller/filehandlingcontroller.php
@@ -89,7 +89,7 @@ class FileHandlingController extends Controller{
 					$writable = $this->view->isUpdatable($path);
 					$mime = $this->view->getMimeType($path);
 					$mTime = $this->view->filemtime($path);
-					$encoding = mb_detect_encoding($fileContents . "a", "UTF-8, WINDOWS-1252, ISO-8859-15, ISO-8859-1, ASCII", true);
+					$encoding = mb_detect_encoding($fileContents . "a", "UTF-8, WINDOWS-1252, SJIS-win, ISO-8859-15, ISO-8859-1, ASCII", true);
 					if ($encoding == "") {
 						// set default encoding if it couldn't be detected
 						$encoding = 'ISO-8859-15';


### PR DESCRIPTION
I'm confirm fix Shift-JIS code misdetection ownCloud 9.0.2.
# test pattern
- Shift-JIS Japanese text file
- UTF-8 Japanese text file

Please **Merge** this and include future releases.
