### PR TITLE
Travis sudo required is being used so specify it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+sudo: required
 php:
   - 5.6
   - 7


### PR DESCRIPTION
If someone forks this repo and then enables their fork in Travis and tries to build, then they get a phpunit error like:
```
$ phpunit --configuration phpunit.xml
PHP Fatal error:  Call to undefined method PHPUnit_Util_Configuration::getTestdoxGroupConfiguration() in /home/travis/build/phil-davis/core/lib/composer/phpunit/phpunit/src/TextUI/TestRunner.php on line 1076
PHP Stack trace:
PHP   1. {main}() /home/travis/.phpenv/versions/5.6.5/bin/phpunit:0
PHP   2. PHPUnit_TextUI_Command::main() /home/travis/.phpenv/versions/5.6.5/bin/phpunit:722
PHP   3. PHPUnit_TextUI_Command->run() phar:///home/travis/.phpenv/versions/5.6.5/bin/phpunit/phpunit/TextUI/Command.php:104
PHP   4. PHPUnit_TextUI_TestRunner->doRun() phar:///home/travis/.phpenv/versions/5.6.5/bin/phpunit/phpunit/TextUI/Command.php:152
PHP   5. PHPUnit_TextUI_TestRunner->handleConfiguration() /home/travis/build/phil-davis/core/lib/composer/phpunit/phpunit/src/TextUI/TestRunner.php:167
```
In their (new) fork, the build runs by default in the Travis container used for "sudo: false".
However the build in the real ownCloud repo is actually running in the Travis container used for "sudo: required", which is a bit different:
![owncloudtexteditorbuild-sudo-required](https://user-images.githubusercontent.com/1535615/27021377-a2150580-4f67-11e7-877a-b9a1d7764518.png)

Repos created before 2015 use "sudo: required" by default, and since 2015 "sudo: false" is the default.
https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments

This is all rather tricky to understand what happened. It will be easier for others if "sudo: required" is explicitly mentioned here, since that is what actually happens. As a separate task, the need for "sudo: required" could be investigated and changed to "sudo: false" if appropriate.

Signed-off-by: Phil Davis <phil@jankaritech.com>