### PR TITLE
Changelog for changes since V2.2 2017-05-09

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this app will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+### Fixed
+#### UI Related
+- Add viewBox to app icon for proper scaling in firefox [#187] (https://github.com/owncloud/files_texteditor/pull/187)
+- Revert "added mime type for .htaccess files" [#200] (https://github.com/owncloud/files_texteditor/pull/200)
+
+#### App Build and Test
+- Implement automated UI test environment [#204] (https://github.com/owncloud/files_texteditor/pull/204)
+
+### Updated
+- Update ace and replace searchbox extension for search support [#196] (https://github.com/owncloud/files_texteditor/pull/196)
+
+[Unreleased]: https://github.com/owncloud/files_texteditor/compare/v2.2...master


### PR DESCRIPTION
hmmm - there does not seem to be a v2.2 tag to diff from in GitHub.
I guess that apps in the past have had different ways of doing branching and tagging.