### PR TITLE
Bump version to 2.2.1

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -2,12 +2,12 @@
 <info>
 	<id>files_texteditor</id>
 	<name>Text Editor</name>
-	<description>This application enables ownCloud users to open, save and edit text files in the web browser. If enabled, an entry for Text file is shown in the New button at the top of the web browser. When clicked, a new text file opens in the browser and the file can be saved into the current ownCloud directory. Further, when a text file is clicked in the web browser, it will be opened and editable. If the privileges allow, a user can also edit shared files and save these changes back into the web browser.
+	<description>This application enables ownCloud users to open, save and edit text files in the web browser. If enabled, an entry for Text file is shown in the New button at the top of the web browser. When clicked, a new text file opens in the browser and the file is saved into the current ownCloud directory. Further, when a text file is clicked in the web browser, it will be opened and editable. If the privileges allow, a user can also edit shared files and save these changes back into the web browser.
 More information is available in the Text Editor documentation.
 	</description>
 	<licence>AGPL</licence>
 	<author>Tom Needham, Björn Schießle</author>
-	<version>2.2</version>
+	<version>2.2.1</version>
 	<default_enable/>
 	<documentation>
 		<user>https://github.com/owncloud/files_texteditor/blob/master/README.md</user>


### PR DESCRIPTION
The stuff in the changelog is nothing mind-blowing. So I suspect a point release to 2.2.1 is in order.

Change the description to mention that the file IS saved. The editor window auto-saves - there is no chance for the user to bail out of editing without saving.