### PR TITLE
Use new core ability to specify APPS_TO_ENABLE for UI test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-sudo: required
+sudo: false
 php:
   - 5.6
   - 7.0

--- a/tests/travis/start_ui_tests.sh
+++ b/tests/travis/start_ui_tests.sh
@@ -5,59 +5,6 @@
 # @author Phillip Davis <phil@jankaritech.com>
 # @copyright 2017 Phillip Davis phil@jankaritech.com
 #
-
-#@param $1 admin password
-#@param $2 occ url
-#@param $3 command
-#sets $REMOTE_OCC_STDOUT and $REMOTE_OCC_STDERR from returned xml date
-#@return occ return code given in the xml data
-remote_occ() {
-	RESULT=`curl -s -u admin:$1 $2 -d "command=$3"`
-	RETURN=`echo $RESULT | xmllint --xpath "string(ocs/data/code)" - | sed 's/ //g'`
-	#we could not find a proper return of the testing app, so something went wrong
-	if [ -z "$RETURN" ]
-	then
-		RETURN=1
-		REMOTE_OCC_STDERR=$RESULT
-	else
-		REMOTE_OCC_STDOUT=`echo $RESULT | xmllint --xpath "string(ocs/data/stdOut)" - | sed 's/ //g'`
-		REMOTE_OCC_STDERR=`echo $RESULT | xmllint --xpath "string(ocs/data/stdErr)" - | sed 's/ //g'`
-	fi
-	return $RETURN
-}
-
-
-BASE_URL="http://$SRV_HOST_NAME"
-if [ ! -z "$SRV_HOST_PORT" ] && [ "$SRV_HOST_PORT" != "80" ]
-then
-	BASE_URL="$BASE_URL:$SRV_HOST_PORT"
-fi
-
-if [ -n "$SRV_HOST_URL" ]
-then
-	BASE_URL="$BASE_URL/$SRV_HOST_URL"
-fi
-
-OCC_URL="$BASE_URL/ocs/v2.php/apps/testing/api/v1/occ"
-if [ -z "$ADMIN_PASSWORD" ]
-then
-	ADMIN_PASSWORD="admin"
-fi
-
-remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings app:list ^files_texteditor"
-PREVIOUS_FILES_TEXTEDITOR_APP_STATUS=$REMOTE_OCC_STDOUT
-
-if [[ "$PREVIOUS_FILES_TEXTEDITOR_APP_STATUS" =~ ^Disabled: ]]
-then
-	FILES_TEXTEDITOR_APP_ENABLED_BY_SCRIPT=true;
-	remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings app:enable files_texteditor"
-else
-	FILES_TEXTEDITOR_APP_ENABLED_BY_SCRIPT=false;
-fi
-
 echo "Running UI tests"
+export APPS_TO_ENABLE="files_texteditor"
 bash tests/travis/start_ui_tests.sh --config apps/files_texteditor/tests/ui/config/behat.yml
-
-if test "$FILES_TEXTEDITOR_APP_ENABLED_BY_SCRIPT" = true; then
-	remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings app:disable files_texteditor"
-fi

--- a/tests/ui/config/behat.yml
+++ b/tests/ui/config/behat.yml
@@ -10,7 +10,7 @@ default:
         - %paths.base%/../features
       context:
         parameters:
-          ocPath: ./
+          ocPath: apps/testing/api/v1/occ
           adminPassword: admin
           regularUserPassword: 123456
           regularUserName: regularuser

--- a/tests/ui/features/bootstrap/TextEditorContext.php
+++ b/tests/ui/features/bootstrap/TextEditorContext.php
@@ -36,9 +36,6 @@ require_once 'bootstrap.php';
  */
 class TextEditorContext extends RawMinkContext implements Context {
 
-	use BasicStructure;
-
-	private $adminPassword;
 	private $textEditorPage;
 	private $featureContext;
 	private $filesContext;
@@ -161,12 +158,5 @@ class TextEditorContext extends RawMinkContext implements Context {
 		$this->featureContext = $environment->getContext('FeatureContext');
 		$this->filesContext = $environment->getContext('FilesContext');
 		$this->tmpDir = $this->getMinkParameter("show_tmp_dir");
-		// Initialize the setup helper so it can be used
-		$suiteParameters = SetupHelper::getSuiteParameters($scope);
-		$this->adminPassword = (string)$suiteParameters['adminPassword'];
-		SetupHelper::init(
-			"admin", $this->getUserPassword("admin"),
-			$this->getMinkParameter('base_url'), $suiteParameters['ocPath']
-		);
 	}
 }

--- a/tests/ui/features/textfiles.feature
+++ b/tests/ui/features/textfiles.feature
@@ -1,3 +1,4 @@
+@insulated
 Feature: textFiles
 
 	Background:


### PR DESCRIPTION
A change to core ``start_ui_tests.sh`` allows the caller to specify the apps to be enabled for the test by using environment variable ``APPS_TO_ENABLE`` 

Make use of that to reduce code duplication.

Also here:
1) change to using ``sudo: false`` on Travis - we do not need ``sudo`` and the Travis VM will start more quickly.
2) Fixup ``ocPath`` so that it points to the correct place where the testing app API lives.
3) Remove the ``SetupHelper::init`` from ``TextEditorContext`` - that is already in core ``FeatureContext`` that is part of the loaded environment for the tests anyway.
4) Add ``insulate`` to the feature file. That gives us a separate SauceLabs video for each scenario, which is easier to review if a scenario fails.