### PR TITLE
Refactor UI test steps to match core changes

### DIFF
--- a/tests/acceptance/features/bootstrap/TextEditorContext.php
+++ b/tests/acceptance/features/bootstrap/TextEditorContext.php
@@ -47,13 +47,14 @@ class TextEditorContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When /^I create a text file with the name ((?:'[^']*')|(?:"[^"]*"))( without changing the default file extension|)$/
+	 * @When /^the user creates a text file with the name ((?:'[^']*')|(?:"[^"]*")) using the webUI( without changing the default file extension|)$/
 	 *
 	 * @param string $name
 	 * @param string $useDefaultFileExtension
+	 *
 	 * @return void
 	 */
-	public function createATextFileWithTheName(
+	public function createATextFileWithTheNameUsingTheWebUI(
 		$name,
 		$useDefaultFileExtension = ''
 	) {
@@ -70,11 +71,15 @@ class TextEditorContext extends RawMinkContext implements Context {
 
 
 	/**
-	 * @Then near the new text file box a tooltip with the text :toolTipText should be displayed
+	 * @Then near the new text file box a tooltip with the text :toolTipText should be displayed on the webUI
+	 *
 	 * @param string $toolTipText
+	 *
 	 * @return void
 	 */
-	public function nearTheNewTextFileBoxATooltipShouldBeDisplayed($toolTipText) {
+	public function nearTheNewTextFileBoxATooltipShouldBeDisplayedOnTheWebUI(
+		$toolTipText
+	) {
 		PHPUnit_Framework_Assert::assertEquals(
 			$toolTipText,
 			$this->textEditorPage->getTooltipOfNewTextFileBox()
@@ -82,11 +87,13 @@ class TextEditorContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When I input :text in the text area
+	 * @When the user inputs :text in the text area
+	 *
 	 * @param string $text
+	 *
 	 * @return void
 	 */
-	public function iInputTextInTheTextArea($text) {
+	public function theUserInputsTextInTheTextArea($text) {
 		$this->textEditorPage->typeIntoTextFile(
 			$this->getSession(),
 			$text
@@ -94,11 +101,15 @@ class TextEditorContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When I input the following text in the text area:
+	 * @When the user inputs the following text in the text area:
+	 *
 	 * @param PyStringNode $multiLineText
+	 *
 	 * @return void
 	 */
-	public function iInputTheFollowingInTheTextArea(PyStringNode $multiLineText) {
+	public function theUserInputsTheFollowingInTheTextArea(
+		PyStringNode $multiLineText
+	) {
 		$this->textEditorPage->typeIntoTextFile(
 			$this->getSession(),
 			$multiLineText->getRaw()
@@ -106,11 +117,13 @@ class TextEditorContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then there is/are :number line(s) of text
+	 * @Then there should be :number line(s) of text in the text area
+	 *
 	 * @param int $number
+	 *
 	 * @return void
 	 */
-	public function thereAreLinesOfText($number) {
+	public function thereShouldBeLinesOfTextInTheTextArea($number) {
 		PHPUnit_Framework_Assert::assertEquals(
 			$number,
 			count($this->textEditorPage->textFileContent())
@@ -118,12 +131,14 @@ class TextEditorContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then line :number of the text is :text
+	 * @Then line :number of the text should be :text
+	 *
 	 * @param int $number
 	 * @param string $text
+	 *
 	 * @return void
 	 */
-	public function lineOfTheTextIs($number, $text) {
+	public function lineOfTheTextShouldBe($number, $text) {
 		$lineIndex = $number - 1;
 		$textFileContent = $this->textEditorPage->textFileContent();
 		PHPUnit_Framework_Assert::assertEquals(
@@ -132,10 +147,11 @@ class TextEditorContext extends RawMinkContext implements Context {
 		);
 	}
 	/**
-	 * @When I close the text editor
+	 * @When the user closes the text editor
+	 *
 	 * @return void
 	 */
-	public function iCloseTheTextEditor() {
+	public function theUserClosesTheTextEditor() {
 		$this->textEditorPage->closeTheTextEditor($this->getSession());
 	}
 
@@ -144,9 +160,11 @@ class TextEditorContext extends RawMinkContext implements Context {
 	 * This will run before EVERY scenario.
 	 * It will set the properties for this object.
 	 *
-	 * @param BeforeScenarioScope $scope
-	 * @return void
 	 * @BeforeScenario
+	 *
+	 * @param BeforeScenarioScope $scope
+	 *
+	 * @return void
 	 */
 	public function before(BeforeScenarioScope $scope) {
 		// Get the environment

--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -1,4 +1,25 @@
 <?php
+/**
+ * ownCloud
+ *
+ * @author Phillip Davis <phil@jankaritech.com>
+ * @copyright 2017 Phillip Davis phil@jankaritech.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 require __DIR__ . '/../../../../../../lib/composer/autoload.php';
 require __DIR__ . '/../../../../../../tests/acceptance/features/bootstrap/WebUIBasicStructure.php';
 require __DIR__ . '/../../../../../../tests/acceptance/features/bootstrap/WebUIGeneralContext.php';

--- a/tests/acceptance/features/lib/TextEditorPage.php
+++ b/tests/acceptance/features/lib/TextEditorPage.php
@@ -52,6 +52,7 @@ class TextEditorPage extends FilesPage {
 	 * @param string $xpath
 	 * @param string $text
 	 * @param bool $pressEnter
+	 *
 	 * @throws ElementNotFoundException
 	 * @return void
 	 */
@@ -87,6 +88,7 @@ class TextEditorPage extends FilesPage {
 	 * @param Session $session
 	 * @param string $name
 	 * @param boolean $useDefaultFileExtension
+	 *
 	 * @return void
 	 */
 	public function createTextFile(
@@ -167,6 +169,7 @@ class TextEditorPage extends FilesPage {
 	 *
 	 * @param Session $session
 	 * @param string $text
+	 *
 	 * @return void
 	 */
 	public function typeIntoTextFile(
@@ -206,6 +209,7 @@ class TextEditorPage extends FilesPage {
 	/**
 	 *
 	 * @param Session $session
+	 *
 	 * @throws ElementNotFoundException
 	 * @return void
 	 */
@@ -223,6 +227,7 @@ class TextEditorPage extends FilesPage {
 
 	/**
 	 * @param int $timeout_msec
+	 *
 	 * @return void
 	 */
 	public function waitTillEditorIsLoaded(

--- a/tests/acceptance/features/textfiles.feature
+++ b/tests/acceptance/features/textfiles.feature
@@ -2,18 +2,18 @@
 Feature: textFiles
 
 	Background:
-		Given a regular user exists
-		And I am logged in as a regular user
-		And I am on the files page
+		Given a regular user has been created
+		And the regular user has logged in using the webUI
+		And the user has browsed to the files page
 
 	Scenario Outline: Create a text file
 		When I create a text file with the name <file_name>
 		And I input <example_text> in the text area
 		And I close the text editor
-		Then the file <file_name> should be listed
-		And the files page is reloaded
-		Then the file <file_name> should be listed
-		And I open the file <file_name>
+		Then the file <file_name> should be listed on the webUI
+		And the user reloads the current page of the webUI
+		Then the file <file_name> should be listed on the webUI
+		And the user opens the file <file_name> using the webUI
 		Then there is 1 line of text
 		And line 1 of the text is <example_text>
 		Examples:
@@ -26,25 +26,25 @@ Feature: textFiles
 		When I create a text file with the name ""
 		And I input "stuff" in the text area
 		And I close the text editor
-		Then the file "New text file.txt" should be listed
-		And the files page is reloaded
-		Then the file "New text file.txt" should be listed
+		Then the file "New text file.txt" should be listed on the webUI
+		And the user reloads the current page of the webUI
+		Then the file "New text file.txt" should be listed on the webUI
 
 	Scenario: Create a text file with the default file extension and do not close the editor
 		When I create a text file with the name "abc" without changing the default file extension
 		And I input "something" in the text area
-		Then the file "abc.txt" should be listed
-		And the files page is reloaded
-		Then the file "abc.txt" should be listed
+		Then the file "abc.txt" should be listed on the webUI
+		And the user reloads the current page of the webUI
+		Then the file "abc.txt" should be listed on the webUI
 
 	Scenario: Create a text file with the default file extension and unicode file name
 		When I create a text file with the name "सिमप्ले text file" without changing the default file extension
 		And I input "नेपाल" in the text area
 		And I close the text editor
-		Then the file "सिमप्ले text file.txt" should be listed
-		And the files page is reloaded
-		Then the file "सिमप्ले text file.txt" should be listed
-		And I open the file "सिमप्ले text file.txt"
+		Then the file "सिमप्ले text file.txt" should be listed on the webUI
+		And the user reloads the current page of the webUI
+		Then the file "सिमप्ले text file.txt" should be listed on the webUI
+		And the user opens the file "सिमप्ले text file.txt" using the webUI
 		Then there is 1 line of text
 		And line 1 of the text is "नेपाल"
 
@@ -60,10 +60,10 @@ Feature: textFiles
 		1 2 3 4 5 6 7 8 9 0
 		"""
 		And I close the text editor
-		Then the file "atextfile.txt" should be listed
-		And the files page is reloaded
-		Then the file "atextfile.txt" should be listed
-		And I open the file "atextfile.txt"
+		Then the file "atextfile.txt" should be listed on the webUI
+		And the user reloads the current page of the webUI
+		Then the file "atextfile.txt" should be listed on the webUI
+		And the user opens the file "atextfile.txt" using the webUI
 		Then there are 6 lines of text
 		And line 1 of the text is "What is this?"
 		And line 2 of the text is 'This is some "example" text!'
@@ -73,29 +73,29 @@ Feature: textFiles
 		And line 6 of the text is "1 2 3 4 5 6 7 8 9 0"
 
 	Scenario: Create a text file with the default name and file extension in a sub-folder
-		When I open the folder "simple-folder"
+		When the user opens the folder "simple-folder" using the webUI
 		And I create a text file with the name ""
 		And I input "stuff" in the text area
 		And I close the text editor
-		Then the file "New text file.txt" should be listed
-		And the files page is reloaded
-		Then the file "New text file.txt" should be listed
-		And I open the file "New text file.txt"
+		Then the file "New text file.txt" should be listed on the webUI
+		And the user reloads the current page of the webUI
+		Then the file "New text file.txt" should be listed on the webUI
+		And the user opens the file "New text file.txt" using the webUI
 		Then line 1 of the text is "stuff"
 		And I input "other text before " in the text area
 		And I close the text editor
-		And I open the file "New text file.txt"
+		And the user opens the file "New text file.txt" using the webUI
 		Then line 1 of the text is "other text before stuff"
 
 	Scenario: Create a text file in a sub-folder using special characters in the names
-		When I create a folder with the name "सिमप्ले फोल्देर $%#?&@"
-		And I open the folder "सिमप्ले फोल्देर $%#?&@"
+		When the user creates a folder with the name "सिमप्ले फोल्देर $%#?&@" using the webUI
+		And the user opens the folder "सिमप्ले फोल्देर $%#?&@" using the webUI
 		And I create a text file with the name "सिमप्ले $%#?&@ name.txt"
 		And I input "a line of text" in the text area
 		And I close the text editor
-		Then the file "सिमप्ले $%#?&@ name.txt" should be listed
-		And the files page is reloaded
-		Then the file "सिमप्ले $%#?&@ name.txt" should be listed
+		Then the file "सिमप्ले $%#?&@ name.txt" should be listed on the webUI
+		And the user reloads the current page of the webUI
+		Then the file "सिमप्ले $%#?&@ name.txt" should be listed on the webUI
 
 	Scenario: Create a text file putting a name of a file which already exists
 		When I create a text file with the name "lorem.txt"

--- a/tests/acceptance/features/textfiles.feature
+++ b/tests/acceptance/features/textfiles.feature
@@ -7,15 +7,15 @@ Feature: textFiles
 		And the user has browsed to the files page
 
 	Scenario Outline: Create a text file
-		When I create a text file with the name <file_name>
-		And I input <example_text> in the text area
-		And I close the text editor
+		When the user creates a text file with the name <file_name> using the webUI
+		And the user inputs <example_text> in the text area
+		And the user closes the text editor
 		Then the file <file_name> should be listed on the webUI
 		And the user reloads the current page of the webUI
 		Then the file <file_name> should be listed on the webUI
 		And the user opens the file <file_name> using the webUI
-		Then there is 1 line of text
-		And line 1 of the text is <example_text>
+		Then there should be 1 line of text in the text area
+		And line 1 of the text should be <example_text>
 		Examples:
 			|file_name               |example_text                      |
 			|'सिमप्ले text file.txt'    |'some text'                       |
@@ -23,34 +23,34 @@ Feature: textFiles
 			|"'somequotes2' text.txt"|'special !@#$%^&*()[]{}\|-_+=\/?' |
 
 	Scenario: Create a text file with the default name and file extension
-		When I create a text file with the name ""
-		And I input "stuff" in the text area
-		And I close the text editor
+		When the user creates a text file with the name "" using the webUI
+		And the user inputs "stuff" in the text area
+		And the user closes the text editor
 		Then the file "New text file.txt" should be listed on the webUI
 		And the user reloads the current page of the webUI
 		Then the file "New text file.txt" should be listed on the webUI
 
 	Scenario: Create a text file with the default file extension and do not close the editor
-		When I create a text file with the name "abc" without changing the default file extension
-		And I input "something" in the text area
+		When the user creates a text file with the name "abc" using the webUI without changing the default file extension
+		And the user inputs "something" in the text area
 		Then the file "abc.txt" should be listed on the webUI
 		And the user reloads the current page of the webUI
 		Then the file "abc.txt" should be listed on the webUI
 
 	Scenario: Create a text file with the default file extension and unicode file name
-		When I create a text file with the name "सिमप्ले text file" without changing the default file extension
-		And I input "नेपाल" in the text area
-		And I close the text editor
+		When the user creates a text file with the name "सिमप्ले text file" using the webUI without changing the default file extension
+		And the user inputs "नेपाल" in the text area
+		And the user closes the text editor
 		Then the file "सिमप्ले text file.txt" should be listed on the webUI
 		And the user reloads the current page of the webUI
 		Then the file "सिमप्ले text file.txt" should be listed on the webUI
 		And the user opens the file "सिमप्ले text file.txt" using the webUI
-		Then there is 1 line of text
-		And line 1 of the text is "नेपाल"
+		Then there should be 1 line of text in the text area
+		And line 1 of the text should be "नेपाल"
 
 	Scenario: Create a text file with multiple lines of text in it
-		When I create a text file with the name "atextfile.txt"
-		And I input the following text in the text area:
+		When the user creates a text file with the name "atextfile.txt" using the webUI
+		And the user inputs the following text in the text area:
 		"""
 		What is this?
 		This is some "example" text!
@@ -59,60 +59,60 @@ Feature: textFiles
 		नेपाल
 		1 2 3 4 5 6 7 8 9 0
 		"""
-		And I close the text editor
+		And the user closes the text editor
 		Then the file "atextfile.txt" should be listed on the webUI
 		And the user reloads the current page of the webUI
 		Then the file "atextfile.txt" should be listed on the webUI
 		And the user opens the file "atextfile.txt" using the webUI
-		Then there are 6 lines of text
-		And line 1 of the text is "What is this?"
-		And line 2 of the text is 'This is some "example" text!'
-		And line 3 of the text is "That goes on some lines in a 'text' file."
-		And line 4 of the text is ""
-		And line 5 of the text is "नेपाल"
-		And line 6 of the text is "1 2 3 4 5 6 7 8 9 0"
+		Then there should be 6 lines of text in the text area
+		And line 1 of the text should be "What is this?"
+		And line 2 of the text should be 'This is some "example" text!'
+		And line 3 of the text should be "That goes on some lines in a 'text' file."
+		And line 4 of the text should be ""
+		And line 5 of the text should be "नेपाल"
+		And line 6 of the text should be "1 2 3 4 5 6 7 8 9 0"
 
 	Scenario: Create a text file with the default name and file extension in a sub-folder
 		When the user opens the folder "simple-folder" using the webUI
-		And I create a text file with the name ""
-		And I input "stuff" in the text area
-		And I close the text editor
+		And the user creates a text file with the name "" using the webUI
+		And the user inputs "stuff" in the text area
+		And the user closes the text editor
 		Then the file "New text file.txt" should be listed on the webUI
 		And the user reloads the current page of the webUI
 		Then the file "New text file.txt" should be listed on the webUI
 		And the user opens the file "New text file.txt" using the webUI
-		Then line 1 of the text is "stuff"
-		And I input "other text before " in the text area
-		And I close the text editor
+		Then line 1 of the text should be "stuff"
+		And the user inputs "other text before " in the text area
+		And the user closes the text editor
 		And the user opens the file "New text file.txt" using the webUI
-		Then line 1 of the text is "other text before stuff"
+		Then line 1 of the text should be "other text before stuff"
 
 	Scenario: Create a text file in a sub-folder using special characters in the names
 		When the user creates a folder with the name "सिमप्ले फोल्देर $%#?&@" using the webUI
 		And the user opens the folder "सिमप्ले फोल्देर $%#?&@" using the webUI
-		And I create a text file with the name "सिमप्ले $%#?&@ name.txt"
-		And I input "a line of text" in the text area
-		And I close the text editor
+		And the user creates a text file with the name "सिमप्ले $%#?&@ name.txt" using the webUI
+		And the user inputs "a line of text" in the text area
+		And the user closes the text editor
 		Then the file "सिमप्ले $%#?&@ name.txt" should be listed on the webUI
 		And the user reloads the current page of the webUI
 		Then the file "सिमप्ले $%#?&@ name.txt" should be listed on the webUI
 
 	Scenario: Create a text file putting a name of a file which already exists
-		When I create a text file with the name "lorem.txt"
-		Then near the new text file box a tooltip with the text 'lorem.txt already exists' should be displayed
+		When the user creates a text file with the name "lorem.txt" using the webUI
+		Then near the new text file box a tooltip with the text 'lorem.txt already exists' should be displayed on the webUI
 
 	Scenario: Create a text file named with forward slash
-		When I create a text file with the name "simple-folder/a.txt"
-		Then near the new text file box a tooltip with the text 'File name cannot contain "/".' should be displayed
+		When the user creates a text file with the name "simple-folder/a.txt" using the webUI
+		Then near the new text file box a tooltip with the text 'File name cannot contain "/".' should be displayed on the webUI
 
 	Scenario: Create a text file named ..
-		When I create a text file with the name ".."
-		Then near the new text file box a tooltip with the text '".." is an invalid file name.' should be displayed
+		When the user creates a text file with the name ".." using the webUI
+		Then near the new text file box a tooltip with the text '".." is an invalid file name.' should be displayed on the webUI
 
 	Scenario: Create a text file named .
-		When I create a text file with the name "."
-		Then near the new text file box a tooltip with the text '"." is an invalid file name.' should be displayed
+		When the user creates a text file with the name "." using the webUI
+		Then near the new text file box a tooltip with the text '"." is an invalid file name.' should be displayed on the webUI
 
 	Scenario: Create a text file with file extension .part
-		When I create a text file with the name "data.part"
-		Then near the new text file box a tooltip with the text '"data.part" has a forbidden file type/extension.' should be displayed
+		When the user creates a text file with the name "data.part" using the webUI
+		Then near the new text file box a tooltip with the text '"data.part" has a forbidden file type/extension.' should be displayed on the webUI


### PR DESCRIPTION
The core UI test step text formats have changed. 

- Update the steps here to match.
- Reword text-editor-specific steps to use the same grammar.
- Adjust code format so ``phpcs`` gives no errors.