### PR TITLE
Put webUI tests into suite called webUITextEditor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ script:
 matrix:
   include:
     - php: 5.6
-      env: DB=sqlite TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" PLATFORM="Windows 10"
+      env: DB=sqlite TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="webUITextEditor" PLATFORM="Windows 10"
       addons:
         apt: *common_apt
         hosts: *common_hosts
@@ -63,7 +63,7 @@ matrix:
     - php: 7.2
       env: DB=sqlite CORE_BRANCH=master
     - php: 7.1
-      env: DB=sqlite CORE_BRANCH=master TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" PLATFORM="Windows 10"
+      env: DB=sqlite CORE_BRANCH=master TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="webUITextEditor" PLATFORM="Windows 10"
       addons:
         apt: *common_apt
         hosts: *common_hosts

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -5,9 +5,9 @@ default:
     SensioLabs\Behat\PageObjectExtension: ~
 
   suites:
-    default:
+    webUITextEditor:
       paths:
-        - %paths.base%/../features
+        - %paths.base%/../features/webUITextEditor
       context:
         parameters:
           ocPath: apps/testing/api/v1/occ

--- a/tests/acceptance/features/webUITextEditor/createTextFiles.feature
+++ b/tests/acceptance/features/webUITextEditor/createTextFiles.feature
@@ -85,10 +85,6 @@ Feature: textFiles
 		Then the file "New text file.txt" should be listed on the webUI
 		And the user opens the file "New text file.txt" using the webUI
 		Then line 1 of the text should be "stuff"
-		And the user inputs "other text before " in the text area
-		And the user closes the text editor
-		And the user opens the file "New text file.txt" using the webUI
-		Then line 1 of the text should be "other text before stuff"
 
 	Scenario: Create a text file in a sub-folder using special characters in the names
 		When the user creates a folder with the name "सिमप्ले फोल्देर $%#?&@" using the webUI

--- a/tests/acceptance/features/webUITextEditor/editTextFiles.feature
+++ b/tests/acceptance/features/webUITextEditor/editTextFiles.feature
@@ -1,0 +1,25 @@
+@webUI @insulated
+Feature: textFiles
+
+	Background:
+		Given these users have been created:
+			|username|password|displayname|email       |
+			|user1   |1234    |User One   |u1@oc.com.np|
+		And the user has browsed to the login page
+		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has browsed to the files page
+
+	Scenario: Edit a text file with the default name and file extension in a sub-folder
+		When the user opens the folder "simple-folder" using the webUI
+		And the user creates a text file with the name "" using the webUI
+		And the user inputs "stuff" in the text area
+		And the user closes the text editor
+		Then the file "New text file.txt" should be listed on the webUI
+		And the user reloads the current page of the webUI
+		Then the file "New text file.txt" should be listed on the webUI
+		And the user opens the file "New text file.txt" using the webUI
+		Then line 1 of the text should be "stuff"
+		And the user inputs "other text before " in the text area
+		And the user closes the text editor
+		And the user opens the file "New text file.txt" using the webUI
+		Then line 1 of the text should be "other text before stuff"


### PR DESCRIPTION
The core ``start_ui_tests.sh`` script now expects webUI tests to be in suites in folders under the ``features`` folder.