### PR TITLE
Catch StaleElementReference from fillField

### DIFF
--- a/tests/acceptance/features/lib/TextEditorPage.php
+++ b/tests/acceptance/features/lib/TextEditorPage.php
@@ -24,6 +24,8 @@ namespace Page;
 
 use Behat\Mink\Session;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
+use WebDriver\Exception\NoSuchElement;
+use WebDriver\Exception\StaleElementReference;
 use WebDriver\Key;
 
 /**
@@ -128,11 +130,17 @@ class TextEditorPage extends FilesPage {
 			} else {
 				try {
 					$this->fillField($this->newTextFileNameInputLabel, $name . "\n");
-				} catch (\WebDriver\Exception\NoSuchElement $e) {
+				} catch (NoSuchElement $e) {
 					// this seems to be a bug in MinkSelenium2Driver.
 					// used to work fine in 1.3.1 but now throws this exception
 					// actually all that we need does happen,
 					// so we just don't do anything
+				} catch (StaleElementReference $e) {
+					// At the end of processing setValue, MinkSelenium2Driver tries to blur
+					// away from the element. But we pressed enter which has already
+					// made the element go away. So we do not care about this exception.
+					// This issue started happening due to:
+					// https://github.com/minkphp/MinkSelenium2Driver/pull/286
 				}
 			}
 		} else {


### PR DESCRIPTION
as was done in core https://github.com/owncloud/core/pull/32144
See core issue https://github.com/owncloud/core/issues/32143 for details of the cause.