### PR TITLE
Use run.sh for webUI tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Mac OS
 .DS_Store
 # Tests - auto-generated files
+/tests/acceptance/output
 /tests/coverage*
 /tests/clover.xml
 # Remove unnecessary workers

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -1,8 +1,6 @@
 default:
   autoload:
     '': %paths.base%/../features/bootstrap
-  extensions:
-    SensioLabs\Behat\PageObjectExtension: ~
 
   suites:
     webUITextEditor:
@@ -25,3 +23,10 @@ default:
         - WebUIGeneralContext:
         - WebUILoginContext:
         - WebUIFilesContext:
+
+  extensions:
+      jarnaiz\JUnitFormatter\JUnitFormatterExtension:
+          filename: report.xml
+          outputDir: %paths.base%/../output/
+
+      rdx\behatvars\BehatVariablesExtension: ~

--- a/tests/travis/start_ui_tests.sh
+++ b/tests/travis/start_ui_tests.sh
@@ -7,4 +7,8 @@
 #
 echo "Running UI tests"
 export APPS_TO_ENABLE="files_texteditor"
-bash tests/travis/start_ui_tests.sh --config apps/files_texteditor/tests/acceptance/config/behat.yml
+pushd tests/acceptance
+./run.sh --config ../../apps/files_texteditor/tests/acceptance/config/behat.yml --suite webUITextEditor
+ACCEPTANCE_TEST_EXIT_STATUS=$?
+popd
+exit $ACCEPTANCE_TEST_EXIT_STATUS


### PR DESCRIPTION
After core https://github.com/owncloud/core/pull/31348 it is possible to run webUI acceptance tests from the common ``tests/acceptance/run.sh`` script, so do it.

Note: this app is still using Travis/SauceLabs to run the tests, so I have left it with its existing little stub ``tests/travis/start_ui_tests.sh`` script. That stuff can go when ``files_texteditor`` CI is moved to drone.