### PR TITLE
add --remote for running acceptance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ test-php-unit-dbg: vendor/bin/phpunit
 .PHONY: test-acceptance-webui
 test-acceptance-webui:     ## Run webUI acceptance tests
 test-acceptance-webui: vendor/bin/phpunit
-	../../tests/acceptance/run.sh --type webUI
+	../../tests/acceptance/run.sh --remote --type webUI
 
 #
 # Dependency management


### PR DESCRIPTION
Add the ``--remote`` switch when running acceptance tests. This helps in situations where the system-under-test and the test runner are on different systems, or running as different users. e.g. when a developer is running their server as ``www-data`` and the test runner is running as themselves.
