### PR TITLE
adjust acceptance test time constant names

### DIFF
--- a/tests/acceptance/features/lib/TextEditorPage.php
+++ b/tests/acceptance/features/lib/TextEditorPage.php
@@ -233,7 +233,7 @@ class TextEditorPage extends FilesPage {
 	 * @return void
 	 */
 	public function waitTillEditorIsLoaded(
-		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$this->waitTillElementIsNotNull($this->textFileEditXpath, $timeout_msec);
 	}


### PR DESCRIPTION
Old forms of the constant names were deprecated by https://github.com/owncloud/core/pull/32781/commits/db4608ace28ed62a00173021416951fb7ac3d994

Use the new forms that have underscores.