### PR TITLE
Delete vendor dir on clean-deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,6 @@ appstore_package_name=$(appstore_build_directory)/$(app_name)
 npm=$(shell which npm 2> /dev/null)
 
 # dependency folders (leave empty if not required)
-composer_deps=vendor
-composer_dev_deps=
 acceptance_test_deps=vendor-bin/behat/vendor
 
 # signing
@@ -47,8 +45,11 @@ PHAN=php -d zend.enable_gc=0 vendor-bin/phan/vendor/bin/phan
 PHPSTAN=php -d zend.enable_gc=0 vendor-bin/phpstan/vendor/bin/phpstan
 BEHAT_BIN=vendor-bin/behat/vendor/bin/behat
 
-.PHONY: all
-all: $(composer_dev_deps)
+.DEFAULT_GOAL := help
+
+# start with displaying help
+help:
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//' | sed -e 's/  */ /' | column -t -s :
 
 # Removes the appstore build
 .PHONY: clean
@@ -57,17 +58,8 @@ clean: clean-deps
 
 .PHONY: clean-deps
 clean-deps:
+	rm -Rf vendor
 	rm -Rf vendor-bin/**/vendor vendor-bin/**/composer.lock
-
-#
-# ownCloud core PHP dependencies
-#
-$(composer_deps): $(COMPOSER_BIN) composer.json composer.lock
-	php $(COMPOSER_BIN) install --no-dev
-
-$(composer_dev_deps): $(COMPOSER_BIN) composer.json composer.lock
-	php $(COMPOSER_BIN) install --dev
-
 
 # Builds the source and appstore package
 .PHONY: dist


### PR DESCRIPTION
1) When doing ``make clean-deps`` also delete the ``vendor`` dir
2) Remove the duplicated ``composer_deps`` stuff that was causing:
```
make
Makefile:161: warning: overriding recipe for target 'vendor'
Makefile:66: warning: ignoring old recipe for target 'vendor'
make: Nothing to be done for 'all'.
```
3) The ``all`` makefile target was doing nothing anyway, get rid of it.
4) Add in the "standard" help target