### PR TITLE
drone notify on failure

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -924,6 +924,10 @@ def notify():
 		'trigger': {
 			'ref': [
 				'refs/tags/**'
+			],
+			'status': [
+				'success',
+				'failure'
 			]
 		}
 	}

--- a/.drone.yml
+++ b/.drone.yml
@@ -1267,6 +1267,9 @@ trigger:
   ref:
   - refs/tags/**
   - refs/heads/master
+  status:
+  - success
+  - failure
 
 depends_on:
 - phpunit-php7.0-sqlite

--- a/vendor-bin/php_codesniffer/composer.json
+++ b/vendor-bin/php_codesniffer/composer.json
@@ -1,5 +1,8 @@
 {
     "require": {
         "squizlabs/php_codesniffer": "3.*"
+    },
+    "conflict": {
+        "squizlabs/php_codesniffer": "3.5.1"
     }
 }


### PR DESCRIPTION
Like https://github.com/owncloud/activity/pull/794

If a nightly build has failure, then nothing is being reported in rocketchat, because the pipelines stop once there is a failure. So the notify pipeline is never executed.

Adjust so that the notify pipeline will execute on both success and failure.