### PR TITLE
Adding encodings (GB2312, GBK ,BIG5, SJIS-win and EUC-JP)

### DIFF
--- a/controller/filehandlingcontroller.php
+++ b/controller/filehandlingcontroller.php
@@ -86,7 +86,7 @@ class FileHandlingController extends Controller {
 					$writable = $this->view->isUpdatable($path);
 					$mime = $this->view->getMimeType($path);
 					$mTime = $this->view->filemtime($path);
-					$encoding = \mb_detect_encoding($fileContents . "a", "UTF-8, WINDOWS-1252, ISO-8859-15, ISO-8859-1, ASCII", true);
+					$encoding = \mb_detect_encoding($fileContents . "a", "UTF-8, GB2312, GBK ,BIG5, WINDOWS-1252, SJIS-win, EUC-JP, ISO-8859-15, ISO-8859-1, ASCII", true);
 					if ($encoding == "") {
 						// set default encoding if it couldn't be detected
 						$encoding = 'ISO-8859-15';


### PR DESCRIPTION
This PR supersedes https://github.com/owncloud/files_texteditor/pull/51, https://github.com/owncloud/files_texteditor/pull/73 and https://github.com/owncloud/files_texteditor/pull/180

All are adding encodings for China and Japan.
Follow the link to read more about [Chinese Character Encoding Standards](https://www.pinyinjoe.com/pinyin/encoding.htm)

This PR gives Chinese and Japanese users a very good probability to use the editor for editing texts in their native language. Without this PR, the text looks scrambled and the editor is useless.

After further research and according to [stackoverflow](https://stackoverflow.com/questions/11782898/what-is-the-preferable-character-encoding-order-for-mb-detect-encoding-in-p),
_There is no true preferred order that gives you the most accurate response._

From the same link above:
_There will always be strings that can potentially be detected and valid in a number of character sets. mb_detect_encoding cannot determine which is the correct one._

After reading many posts including comment https://github.com/owncloud/files_texteditor/pull/73#issuecomment-101236624 (GBK is an extension GB2312), the sort order for Chinese is now defined as "GB2312, GBK, BIG5".

@phil-davis when merged, this is relevant for https://github.com/owncloud/files_texteditor/issues/332 (Release 2.3.1)
