### PR TITLE
Fix PHP phan and stan commands

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -38,7 +38,7 @@ return [
 	// your application should be included in this list.
 	'directory_list' => [
 		'appinfo',
-		'lib',
+		'controller',
 		'vendor',
 		'../../lib',
 		'../../core'

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ test-php-phan: vendor-bin/phan/vendor
 .PHONY: test-php-phpstan
 test-php-phpstan: ## Run phpstan
 test-php-phpstan: vendor-bin/phpstan/vendor
-	$(PHPSTAN) analyse --memory-limit=4G --configuration=./phpstan.neon --no-progress --level=5 appinfo lib
+	$(PHPSTAN) analyse --memory-limit=4G --configuration=./phpstan.neon --no-progress --level=5 appinfo controller
 
 .PHONY: test-acceptance-webui
 test-acceptance-webui: ## Run webUI acceptance tests


### PR DESCRIPTION
Both commands `make test-php-phan` and `make test-php-phpstan` do not work because they look for the directory `lib` which is not available.