### PR TITLE
Add support for manual file locking

### DIFF
--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -51,8 +51,7 @@ class Application extends App {
 				$server->getL10N($c->getAppName()),
 				new View('/' . $uid . '/files'),
 				$server->getLogger(),
-				$server->getUserSession(),
-				$server->getConfig()
+				$server->getUserSession()
 			);
 		});
 	}

--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -50,7 +50,9 @@ class Application extends App {
 				$server->getRequest(),
 				$server->getL10N($c->getAppName()),
 				new View('/' . $uid . '/files'),
-				$server->getLogger()
+				$server->getLogger(),
+				$server->getUserSession(),
+				$server->getConfig()
 			);
 		});
 	}

--- a/controller/filehandlingcontroller.php
+++ b/controller/filehandlingcontroller.php
@@ -28,7 +28,6 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\Files\Storage\IPersistentLockingStorage;
 use OCP\Files\ForbiddenException;
-use OCP\IConfig;
 use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IRequest;
@@ -50,9 +49,6 @@ class FileHandlingController extends Controller {
 	/** @var IUserSession */
 	protected $userSession;
 
-	/** @var IConfig */
-	private $config;
-
 	/**
 	 * @NoAdminRequired
 	 *
@@ -62,21 +58,18 @@ class FileHandlingController extends Controller {
 	 * @param View $view
 	 * @param ILogger $logger
 	 * @param IUserSession $userSession
-	 * @param IConfig $config
 	 */
 	public function __construct($AppName,
 								IRequest $request,
 								IL10N $l10n,
 								View $view,
 								ILogger $logger,
-								IUserSession $userSession,
-								IConfig  $config) {
+								IUserSession $userSession) {
 		parent::__construct($AppName, $request);
 		$this->l = $l10n;
 		$this->view = $view;
 		$this->logger = $logger;
 		$this->userSession = $userSession;
-		$this->config = $config;
 	}
 
 	/**
@@ -164,8 +157,7 @@ class FileHandlingController extends Controller {
 					if ($this->view->isUpdatable($path)) {
 						$fileInfo = $this->view->getFileInfo($path);
 						$storage = $fileInfo->getStorage();
-						$lookingEnabled = $this->config->getAppValue("files", "enable_lock_file_action", "no") === "yes";
-						if ($lookingEnabled && $storage->instanceOfStorage(IPersistentLockingStorage::class)) {
+						if ($storage->instanceOfStorage(IPersistentLockingStorage::class)) {
 							/** @var IPersistentLockingStorage $storage */
 							/* @phan-suppress-next-line PhanUndeclaredMethod */
 							$locks = $storage->getLocks($fileInfo->getInternalPath(), false);

--- a/tests/unit/controller/filehandlingcontrollerTest.php
+++ b/tests/unit/controller/filehandlingcontrollerTest.php
@@ -55,9 +55,6 @@ class FileHandlingControllerTest extends TestCase {
 	/** @var \OCP\IUserSession | \PHPUnit\Framework\MockObject\MockObject */
 	private $userSessionMock;
 
-	/** @var \OCP\IConfig | \PHPUnit\Framework\MockObject\MockObject */
-	private $configMock;
-
 	public function setUp(): void {
 		parent::setUp();
 		$this->appName = 'files_texteditor';
@@ -74,9 +71,6 @@ class FileHandlingControllerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$this->userSessionMock = $this->getMockBuilder('OCP\IUserSession')
-			->disableOriginalConstructor()
-			->getMock();
-		$this->configMock = $this->getMockBuilder('OCP\IConfig')
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -100,8 +94,7 @@ class FileHandlingControllerTest extends TestCase {
 			$this->l10nMock,
 			$this->viewMock,
 			$this->loggerMock,
-			$this->userSessionMock,
-			$this->configMock);
+			$this->userSessionMock);
 	}
 
 	/**
@@ -191,7 +184,16 @@ class FileHandlingControllerTest extends TestCase {
 			->method('isUpdatable')
 			->willReturn(true);
 
+		$storageMock = $this->createMock(IPersistentLockingStorageTest::class);
+		$storageMock->expects($this->any())
+			->method('instanceOfStorage')
+			->willReturn(false);
+
 		$fileInfoMock = $this->createMock('\OCP\Files\FileInfo');
+		$fileInfoMock->expects($this->any())
+			->method('getStorage')
+			->willReturn($storageMock);
+
 		$this->viewMock->expects($this->any())
 			->method('getFileInfo')
 			->willReturn($fileInfoMock);
@@ -224,14 +226,10 @@ class FileHandlingControllerTest extends TestCase {
 			->method('isUpdatable')
 			->willReturn($isUpdatable);
 
-		$this->configMock->expects($this->any())
-			->method('getAppValue')
-			->willReturn('no');
-
 		$storageMock = $this->createMock(IPersistentLockingStorageTest::class);
 		$storageMock->expects($this->any())
 			->method('instanceOfStorage')
-			->willReturn(true);
+			->willReturn(false);
 
 		$fileInfoMock = $this->createMock('\OCP\Files\FileInfo');
 		$fileInfoMock->expects($this->any())
@@ -281,9 +279,6 @@ class FileHandlingControllerTest extends TestCase {
 		$this->viewMock->expects($this->any())
 			->method('isUpdatable')
 			->willReturn(true);
-		$this->configMock->expects($this->any())
-			->method('getAppValue')
-			->willReturn('yes');
 
 		$lockMock = $this->createMock('OCP\Lock\Persistent\ILock');
 		$lockMock->expects($this->any())


### PR DESCRIPTION
OC 10.5 introduced manual file locking. This change adds the functionality to the files texteditor app. How it basically works: User 1 shares a file with User 2, then locks it. Now User 2 is still able to view this file, but editing is not possible and will result in the message "The file is locked" (similar to when it has been locked via transactional locking).

![image](https://user-images.githubusercontent.com/50302941/105484372-7eb6bc00-5cab-11eb-8742-ff77cbcce23f.png)
