### PR TITLE
[tests-only] Activity app now requires core 10.7.1

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -48,6 +48,9 @@ config = {
 			'extraApps': {
 				'activity': ''
 			},
+			'servers': [
+				'daily-master-qa',
+			],
 		},
 	}
 }


### PR DESCRIPTION
Do not test text-editor+activity app combination against an "old" 10.7.0 core.