### PR TITLE
package vendor/firebase/php-jwt

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -45,6 +45,7 @@ config = {
     "branches": [
         "master",
     ],
+    "appInstallCommandPhp": "composer install",
     "codestyle": True,
     "phan": {
         "multipleVersions": {

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ clean-deps:
 
 # Builds the source and appstore package
 .PHONY: dist
-dist:
+dist: vendor
 	make source
 	make appstore
 
@@ -86,6 +86,7 @@ appstore:
 	cp --parents -r \
 	appinfo \
 	controller \
+	vendor \
 	css \
 	img \
 	l10n \

--- a/controller/filehandlingcontroller.php
+++ b/controller/filehandlingcontroller.php
@@ -44,6 +44,8 @@ use Sabre\DAV\Exception\NotFound;
 
 use Firebase\JWT\JWT;
 
+require_once __DIR__ . '/../vendor/autoload.php';
+
 class FileHandlingController extends Controller {
 
 	/** @var IL10N */


### PR DESCRIPTION
It does not seem safe to rely on vendor/firebase/php-jwt from files_external or elsewhere.
Seems we should package and use our own copy.

Fixes #388 