### PR TITLE
Merge back 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this app will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [2.6.0] - 2023-08-11
+
+### Fixed
+
+- [#401](https://github.com/owncloud/files_texteditor/pull/401) - fix: use firebase/php-jwt from core
+
+
 ## [2.5.2] - 2023-07-27
 
 ### Changed
@@ -73,7 +80,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Updated
 - Update ace and replace searchbox extension for search support [#196] (https://github.com/owncloud/files_texteditor/pull/196)
 
-[Unreleased]: https://github.com/owncloud/files_texteditor/compare/v2.5.1...master
+[Unreleased]: https://github.com/owncloud/files_texteditor/compare/v2.6.0...master
+[2.6.0]: https://github.com/owncloud/files_texteditor/compare/v2.5.2...v2.6.0
+[2.5.2]: https://github.com/owncloud/files_texteditor/compare/v2.5.1...v2.5.2
 [2.5.1]: https://github.com/owncloud/files_texteditor/compare/v2.5.0...v2.5.1
 [2.5.0]: https://github.com/owncloud/files_texteditor/compare/v2.4.1...v2.5.0
 [2.4.1]: https://github.com/owncloud/files_texteditor/compare/v2.4.0...v2.4.1

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@
 	</description>
 	<licence>AGPL</licence>
 	<author>Tom Needham, Björn Schießle</author>
-	<version>2.5.2</version>
+	<version>2.6.0</version>
 	<default_enable/>
 	<documentation>
 		<user>https://github.com/owncloud/files_texteditor/blob/master/README.md</user>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # Organization and project keys are displayed in the right sidebar of the project homepage
 sonar.organization=owncloud-1
 sonar.projectKey=owncloud_files_texteditor
-sonar.projectVersion=2.5.2
+sonar.projectVersion=2.6.0
 sonar.host.url=https://sonarcloud.io
 
 # =====================================================


### PR DESCRIPTION
This was released on 11 August 2023:
https://github.com/owncloud/files_texteditor/releases/tag/v2.6.0