### PR TITLE
fix: ensure password has been checked for password-protected shares and have permissions to read the file

### DIFF
--- a/controller/filehandlingcontroller.php
+++ b/controller/filehandlingcontroller.php
@@ -131,7 +131,11 @@ class FileHandlingController extends Controller {
 
 				if ($fileContents !== false) {
 					$permissions = $this->getPermissions($node);
-					
+					if (($permissions & Constants::PERMISSION_READ) !== Constants::PERMISSION_READ) {
+						// if we don't have permissions to read, then abort
+						return new DataResponse(['message' => (string)$this->l->t('Cannot read the file. Not enough permissions')], Http::STATUS_BAD_REQUEST);
+					}
+
 					// handle locks
 					$activePersistentLock = $this->getPersistentLock($node);
 					if ($activePersistentLock && !$this->verifyPersistentLock($node, $activePersistentLock)) {

--- a/controller/filehandlingcontroller.php
+++ b/controller/filehandlingcontroller.php
@@ -355,7 +355,11 @@ class FileHandlingController extends Controller {
 			$sharePassword = $share->getPassword();
 
 			if ($sharePassword !== null) {
-				$authenticatedShareId = $this->userSession->getSession()->get('public_link_authenticated');
+				$authenticatedShareId = null;
+				if ($this->userSession instanceof \OC\User\Session) {
+					// getSession method isn't available in the interface but only in the implementation
+					$authenticatedShareId = $this->userSession->getSession()->get('public_link_authenticated');
+				}
 				if ($authenticatedShareId !== (string)$share->getId()) {
 					throw new HintException('Password required', $this->l->t('Access to this resource requires a password. Either no password has been supplied, or a wrong password has been used'));
 				}

--- a/controller/filehandlingcontroller.php
+++ b/controller/filehandlingcontroller.php
@@ -352,6 +352,15 @@ class FileHandlingController extends Controller {
 
 		if ($sharingToken) {
 			$share = $this->shareManager->getShareByToken($sharingToken);
+			$sharePassword = $share->getPassword();
+
+			if ($sharePassword !== null) {
+				$authenticatedShareId = $this->userSession->getSession()->get('public_link_authenticated');
+				if ($authenticatedShareId !== (string)$share->getId()) {
+					throw new HintException('Password required', $this->l->t('Access to this resource requires a password. Either no password has been supplied, or a wrong password has been used'));
+				}
+			}
+
 			$node = $share->getNode();
 			if (!($node instanceof File)) {
 				$node = $node->get($path);

--- a/tests/unit/controller/filehandlingcontrollerTest.php
+++ b/tests/unit/controller/filehandlingcontrollerTest.php
@@ -431,6 +431,44 @@ class FileHandlingControllerTest extends TestCase {
 		$this->assertSame($data['filecontents'], $fileContent);
 	}
 
+	public function testLoadWithShareFileDrop() {
+		$filename = 'test.txt';
+		$fileContent = 'test';
+
+		$this->requestMock->expects($this->any())
+			->method('getParam')
+			->willReturn('token');
+
+		$this->shareMock->expects($this->any())
+			->method('getNode')
+			->willReturn($this->fileMock);
+
+		$this->shareManagerMock->expects($this->any())
+			->method('getShareByToken')
+			->willReturn($this->shareMock);
+
+		$this->fileMock->expects($this->any())
+			->method('getContent')
+			->willReturn($fileContent);
+
+		$this->fileMock->expects($this->any())
+			->method('getStorage')
+			->willReturn($this->fileStorageMock);
+
+		$this->shareMock->expects($this->any())
+			->method('getPermissions')
+			->willReturn(Constants::PERMISSION_CREATE); // explicit no read permission
+
+		$this->rootMock->expects($this->any())
+			->method('get')
+			->willReturn($this->fileMock);
+
+		$result = $this->controller->load('/', $filename);
+		$data = $result->getData();
+		$status = $result->getStatus();
+		$this->assertSame($status, 400);
+	}
+
 	public function testLoadWithShareWithPassword() {
 		$filename = 'test.txt';
 		$fileContent = 'test';


### PR DESCRIPTION
**Known issue** caused by this PR: only one password-protected link can be accessed at a time.
1. Access to a shared folder that is password-protected. Enter the password and check you can open text files inside.
2. In a different tab, access to a different shared folder that is password-protected. Enter the password and check you can open text files inside
3. Authentication for the first shared folder (step 1) is lost:
    * Trying to open a text file causes an error
    * You'll need to reload the page and enter the password again. Note that this will cause the same problem in the second tab.

Side note: whether the link has been authenticated or not is stored by core. Right now, this information is stored just for one share. Fixing the issue explained above will require changes in core.