### PR TITLE
ci: use reusable build workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,11 +58,9 @@ jobs:
   build:
     name: Build
     needs:
+      - get-vars
       - php-code-style
       - php-unit
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Build
-        run: make dist
+    uses: owncloud/reusable-workflows/.github/workflows/build.yml@main
+    with:
+      app-name: ${{ needs.get-vars.outputs.app-name }}


### PR DESCRIPTION
## Summary
- Replaces the inline `build` job with a call to `owncloud/reusable-workflows/.github/workflows/build.yml@main`
- Adds `get-vars` to `build` job needs so `app-name` output is available
- Depends on owncloud/reusable-workflows#26

## Test plan
- [ ] Verify CI passes end-to-end with the reusable build workflow