### PR TITLE
chore: bump version to 2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased] -
 
 
+## [2.7.1] - 2026-07-22
+
+### Changed
+- Maintenance release re-signed with the ownCloud G2 code-signing certificate for the ownCloud 11.0.0 release.
+
+## [2.7.0] - 2026-06-29
+
+### Changed
+- ownCloud 11 compatible release (oc 11.0.0-rc1).
+
 ## [2.6.2] - 2025-09-18
 
 ### Fixed
@@ -98,7 +108,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Updated
 - Update ace and replace searchbox extension for search support [#196] (https://github.com/owncloud/files_texteditor/pull/196)
 
-[Unreleased]: https://github.com/owncloud/files_texteditor/compare/v2.6.2...master
+[Unreleased]: https://github.com/owncloud/files_texteditor/compare/v2.7.1..master
+[2.7.1]: https://github.com/owncloud/files_texteditor/compare/v2.7.0..v2.7.1
+[2.7.0]: https://github.com/owncloud/files_texteditor/compare/v2.6.2..v2.7.0
 [2.6.2]: https://github.com/owncloud/files_texteditor/compare/v2.6.1...v2.6.2
 [2.6.1]: https://github.com/owncloud/files_texteditor/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/owncloud/files_texteditor/compare/v2.5.2...v2.6.0
@@ -107,7 +119,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 [2.5.0]: https://github.com/owncloud/files_texteditor/compare/v2.4.1...v2.5.0
 [2.4.1]: https://github.com/owncloud/files_texteditor/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/owncloud/files_texteditor/compare/v2.3.2...v2.4.0
-[2.3.2]: https://github.com/owncloud/files_texteditor/compare/v2.3.1...v2.3.2
 [2.3.1]: https://github.com/owncloud/files_texteditor/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/owncloud/files_texteditor/compare/v2.2.1...v2.3.0
 [2.2.1]: https://github.com/owncloud/files_texteditor/compare/v2.2...v2.2.1
+[2.3.2]: https://github.com/owncloud/files_texteditor/compare/v2.3.1...v2.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,9 +108,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Updated
 - Update ace and replace searchbox extension for search support [#196] (https://github.com/owncloud/files_texteditor/pull/196)
 
-[Unreleased]: https://github.com/owncloud/files_texteditor/compare/v2.7.1..master
-[2.7.1]: https://github.com/owncloud/files_texteditor/compare/v2.7.0..v2.7.1
-[2.7.0]: https://github.com/owncloud/files_texteditor/compare/v2.6.2..v2.7.0
+[Unreleased]: https://github.com/owncloud/files_texteditor/compare/v2.7.1...master
+[2.7.1]: https://github.com/owncloud/files_texteditor/compare/v2.7.0...v2.7.1
+[2.7.0]: https://github.com/owncloud/files_texteditor/compare/v2.6.2...v2.7.0
 [2.6.2]: https://github.com/owncloud/files_texteditor/compare/v2.6.1...v2.6.2
 [2.6.1]: https://github.com/owncloud/files_texteditor/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/owncloud/files_texteditor/compare/v2.5.2...v2.6.0
@@ -119,7 +119,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 [2.5.0]: https://github.com/owncloud/files_texteditor/compare/v2.4.1...v2.5.0
 [2.4.1]: https://github.com/owncloud/files_texteditor/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/owncloud/files_texteditor/compare/v2.3.2...v2.4.0
+[2.3.2]: https://github.com/owncloud/files_texteditor/compare/v2.3.1...v2.3.2
 [2.3.1]: https://github.com/owncloud/files_texteditor/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/owncloud/files_texteditor/compare/v2.2.1...v2.3.0
 [2.2.1]: https://github.com/owncloud/files_texteditor/compare/v2.2...v2.2.1
-[2.3.2]: https://github.com/owncloud/files_texteditor/compare/v2.3.1...v2.3.2

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@
 	</description>
 	<licence>AGPL</licence>
 	<author>Tom Needham, Björn Schießle</author>
-	<version>2.7.0</version>
+	<version>2.7.1</version>
 	<default_enable/>
 	<documentation>
 		<user>https://github.com/owncloud/files_texteditor/blob/master/README.md</user>


### PR DESCRIPTION
Patch-level version bump (2.7.0 -> 2.7.1) for the oc11 (11.0.0) complete release. Part of the G2 code-signing re-release.